### PR TITLE
[Medium][Chore] Improve Gallery Responsiveness

### DIFF
--- a/app/css/user-card.scss
+++ b/app/css/user-card.scss
@@ -19,7 +19,7 @@
   }
 
   > .info {
-    flex: 2 0 66%;
+    flex: auto;
     display: flex;
     justify-content: center;
     align-content: center;

--- a/app/css/user-gallery.scss
+++ b/app/css/user-gallery.scss
@@ -3,12 +3,12 @@
 
   > .items {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: auto;
     grid-gap: 16px;
 
-    @media screen and (min-width: 768.1px) {
-      grid-template-columns: 1fr 1fr 1fr;
+    @media screen and (max-width: 480px) {
+      grid-template-columns: 1fr;
     }
   }
 

--- a/app/css/user-gallery.scss
+++ b/app/css/user-gallery.scss
@@ -7,7 +7,7 @@
     grid-template-rows: auto;
     grid-gap: 16px;
 
-    @media screen and (min-width: 768px) {
+    @media (min-width: 701px) and (max-width: 1120px) {
       grid-template-columns: 1fr 1fr;
     }
 

--- a/app/css/user-gallery.scss
+++ b/app/css/user-gallery.scss
@@ -7,6 +7,10 @@
     grid-template-rows: auto;
     grid-gap: 16px;
 
+    @media screen and (min-width: 768px) {
+      grid-template-columns: 1fr 1fr;
+    }
+
     @media screen and (max-width: 480px) {
       grid-template-columns: 1fr;
     }

--- a/app/css/user-gallery.scss
+++ b/app/css/user-gallery.scss
@@ -7,7 +7,7 @@
     grid-template-rows: auto;
     grid-gap: 16px;
 
-    @media (min-width: 701px) and (max-width: 1120px) {
+    @media screen and (min-width: 701px) and (max-width: 1120px) {
       grid-template-columns: 1fr 1fr;
     }
 

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -129,6 +129,10 @@
 
 /* Mobile */
 @media (max-width: 700px) {
+  .main {
+    padding: 2rem;
+  }
+
   .content {
     padding: 4rem;
   }
@@ -206,6 +210,10 @@
 
 /* Tablet and Smaller Desktop */
 @media (min-width: 701px) and (max-width: 1120px) {
+  .main {
+    padding: 2rem;
+  }
+
   .grid {
     grid-template-columns: repeat(2, 50%);
   }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -209,7 +209,7 @@
 }
 
 /* Tablet and Smaller Desktop */
-@media (min-width: 701px) and (max-width: 1120px) {
+@media screen and (min-width: 701px) and (max-width: 1120px) {
   .main {
     padding: 2rem;
   }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -209,7 +209,7 @@
 }
 
 /* Tablet and Smaller Desktop */
-@media screen and (min-width: 701px) and (max-width: 1120px) {
+@media (min-width: 701px) and (max-width: 1120px) {
   .main {
     padding: 2rem;
   }


### PR DESCRIPTION
### Issue:
The gallery is currently optimized for desktop devices and has issues fitting things into place on smaller screens (tablet & mobile).

### Solution:
- set .info flex to auto (previous css [flex: 2 0 66%;] breaking the tablet and mobile view)
- add ` @media screen and (min-width: 701px) and (max-width: 1120px)` to support tablet and make the column 2
- adjust main padding for tablet and mobile view

Please refer to the screenshot below of the fixed gallery (tablet & mobile view).

**Tablet:**
![image](https://github.com/benedictllarena/frontend_test/assets/8186460/24c6aad5-09eb-44e1-88d6-e6b132ee70c3)

**Mobile:**
![image](https://github.com/benedictllarena/frontend_test/assets/8186460/12b310e7-9709-4967-9812-fb6062eb59df)
